### PR TITLE
Improve landing responsiveness and translation fallback

### DIFF
--- a/app/Landing.tsx
+++ b/app/Landing.tsx
@@ -9,13 +9,11 @@ interface LandingProps {
 
 export default function Landing({ onBeginJourney }: LandingProps) {
     return (
-    <div className="min-h-screen flex flex-col">
-        <HeroSection onBeginJourney={onBeginJourney} />
-        <Content />
-        <Faq />
-        <div className="flex ">
-        <Footer />
-        </div>
+    <div className="flex min-h-screen flex-col">
+      <HeroSection onBeginJourney={onBeginJourney} />
+      <Content />
+      <Faq />
+      <Footer />
     </div>
     )
 }

--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -1,5 +1,4 @@
 import { Brain, ShieldCheck, MessageCircle, TrendingUp, Heart, Users } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { motion } from "framer-motion"
 import { useTranslation } from "@/hooks/useTranslation"
 
@@ -8,7 +7,7 @@ export default function Content() {
     return(
         <div>
         {/* Features Section */}
-      <section id="why-choose-anamai" className="relative z-10 py-24 px-6 bg-gradient-to-b from-white to-blue-50/50">
+      <section id="why-choose-anamai" className="relative z-10 bg-gradient-to-b from-white to-blue-50/50 py-20 px-4 sm:px-6">
         <div className="max-w-7xl mx-auto">
           <motion.div 
             initial={{ opacity: 0, y: 50 }}
@@ -148,9 +147,9 @@ export default function Content() {
       </section>
 
       {/* Journey Section */}
-      <section id="wellness-journey" className="relative z-10 py-24 px-6 bg-gradient-to-b from-blue-50/50 to-white">
-        <div className="max-w-7xl mx-auto">
-          <div className="rounded-3xl bg-card border border-border p-12 shadow-lg">
+      <section id="wellness-journey" className="relative z-10 bg-gradient-to-b from-blue-50/50 to-white py-20 px-4 sm:px-6">
+        <div className="mx-auto max-w-7xl">
+          <div className="rounded-3xl bg-card border border-border p-8 shadow-lg sm:p-12">
             {/* Section Header */}
             <motion.div 
               initial={{ opacity: 0, y: 50 }}

--- a/components/Faq.tsx
+++ b/components/Faq.tsx
@@ -1,5 +1,4 @@
 import { Compass, Lock, Sparkles, ShieldCheck, Wallet, Leaf, Plus, Minus, Mail } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { useTranslation } from "@/hooks/useTranslation"
@@ -41,16 +40,17 @@ export default function FAQ() {
     }
   };
     return (
-        <section id="faq-section" className="relative z-10 py-24 px-6 bg-gradient-to-b from-white to-blue-50/30">
-        <div className="max-w-7xl mx-auto">
-          <div className="rounded-3xl bg-card border border-border p-12 shadow-lg">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-start">
+        <section id="faq-section" className="relative z-10 bg-gradient-to-b from-white to-blue-50/30 py-20 px-4 sm:px-6">
+        <div className="mx-auto max-w-7xl">
+          <div className="rounded-3xl bg-card border border-border p-8 shadow-lg sm:p-12">
+            <div className="grid grid-cols-1 items-start gap-12 lg:grid-cols-2 lg:gap-16">
               {/* Left Column - Title and Description */}
               <motion.div
                 initial={{ opacity: 0, x: -50 }}
                 whileInView={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.6 }}
                 viewport={{ once: true }}
+                className="text-center lg:text-left"
               >
                 <h2 className="text-4xl md:text-5xl font-bold tracking-tight mb-6 text-balance text-foreground">
                   {t("faq_title")}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,13 +1,10 @@
-import {
-  Brain,
-} from "lucide-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "@/hooks/useTranslation";
 
 export default function Footer() {
   const { t } = useTranslation();
   return (
-    <footer className="relative z-10 pt-16 pb-0 bg-gradient-to-b from-blue-50/50 via-white to-blue-50/30 mt-auto overflow-hidden w-full">
+    <footer className="relative z-10 mt-auto w-full overflow-hidden bg-gradient-to-b from-blue-50/50 via-white to-blue-50/30 pt-16 pb-0">
       {/* Background decorative elements */}
       <div className="absolute inset-0 opacity-5">
         <div className="absolute top-10 left-10 w-20 h-20 bg-primary rounded-full blur-xl"></div>
@@ -16,37 +13,37 @@ export default function Footer() {
         <div className="absolute bottom-20 left-1/4 w-24 h-24 bg-secondary/30 rounded-full blur-lg"></div>
       </div>
 
-      <div className="w-full relative">
-        <div className="bg-card/80 backdrop-blur-sm border border-border/50 rounded-none pt-8 pb-4 px-8 md:pt-12 md:pb-6 md:px-12 shadow-xl">
+      <div className="relative w-full">
+        <div className="rounded-none border border-border/50 bg-card/80 px-6 pt-8 pb-4 shadow-xl backdrop-blur-sm sm:px-8 md:px-12 md:pt-12 md:pb-6">
           {/* Main Footer Content */}
-          <div className="flex flex-col md:flex-row justify-between items-center mb-12">
+          <div className="mb-12 flex flex-col items-center justify-between gap-6 text-center md:flex-row md:items-start md:gap-8 md:text-left">
             {/* Brand Section */}
-            <motion.div 
+            <motion.div
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
               onClick={() => {
                 window.scrollTo({ top: 0, behavior: 'smooth' });
               }}
-              className="flex items-center gap-3 cursor-pointer transition-all duration-300 hover:opacity-80 w-fit"
+              className="flex w-fit items-center gap-3 cursor-pointer transition-all duration-300 hover:opacity-80"
             >
               <img src="/Logo.png" alt="AnamAI Logo" className="w-12 h-12" />
               <span className="text-3xl font-bold text-primary">
-                {t("footer_anamai")}
+                {t("footer_AnamAi")}
               </span>
             </motion.div>
-            
+
             {/* Description */}
-            <div className="flex-1 max-w-2xl mx-8 mt-4 md:mt-0">
-              <p className="text-muted-foreground leading-relaxed text-pretty text-center md:text-left">
+            <div className="mx-auto mt-2 max-w-2xl md:mx-0 md:mt-0">
+              <p className="text-pretty text-center text-sm leading-relaxed text-muted-foreground sm:text-base md:text-left">
                 {t("footer_description")}
               </p>
             </div>
           </div>
 
           {/* Sub-footer */}
-          <div className="border-t border-border/50 pt-8">
-            <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-              <p className="text-muted-foreground text-sm">
+          <div className="border-t border-border/50 pt-6">
+            <div className="flex flex-col items-center justify-between gap-4 text-center sm:flex-row sm:text-left">
+              <p className="text-sm text-muted-foreground">
                 {t("footer_copyright")}
               </p>
               <div className="flex items-center gap-4 text-xs text-muted-foreground">

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,9 +1,8 @@
-import { ChevronDown } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { useState, useEffect } from "react";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "@/hooks/useTranslation";
 import { LanguageSwitcher } from "./LanguageSwitcher";
-import Link from "next/link";
 
 interface HeroSectionProps {
   onBeginJourney: () => void;
@@ -11,13 +10,13 @@ interface HeroSectionProps {
 
 export default function Home({ onBeginJourney }: HeroSectionProps) {
   const { t } = useTranslation();
-  const [navbarBg, setNavbarBg] = useState("bg-transparent");
   const [navbarOpacity, setNavbarOpacity] = useState(0);
   const [isMounted, setIsMounted] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState("");
   const [isCalling, setIsCalling] = useState(false);
   const [callStatus, setCallStatus] = useState("");
   const [showNumberInput, setShowNumberInput] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const handleMakeCall = async () => {
     if (!showNumberInput) {
@@ -67,14 +66,13 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
       if (scrollPosition >= halfViewportHeight) {
         // Calculate smooth opacity transition from half to full viewport height
         const transitionProgress = Math.min(
-          (scrollPosition - halfViewportHeight) / (fullViewportHeight - halfViewportHeight), 
+          (scrollPosition - halfViewportHeight) /
+            (fullViewportHeight - halfViewportHeight),
           1
         );
-        
-        setNavbarBg("bg-orange-500/80 backdrop-blur-sm border rounded-4xl");
+
         setNavbarOpacity(transitionProgress);
       } else {
-        setNavbarBg("bg-transparent");
         setNavbarOpacity(0);
       }
     };
@@ -83,9 +81,36 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  const handleScrollTo = (sectionId: string) => {
+    const element = document.getElementById(sectionId);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    setIsMobileMenuOpen(false);
+  };
+
+  const navItems = [
+    {
+      key: "mission",
+      label: t("hero_ourMission"),
+      action: () => handleScrollTo("why-choose-anamai"),
+    },
+    {
+      key: "resources",
+      label: t("hero_resources"),
+      action: () => handleScrollTo("wellness-journey"),
+    },
+    {
+      key: "faq",
+      label: t("hero_faq"),
+      action: () => handleScrollTo("faq-section"),
+    },
+  ];
+
+  const isScrolled = navbarOpacity > 0;
+
   return (
     <>
-
       <div className="relative min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-100 overflow-hidden">
         {/* Background Video */}
         <video
@@ -106,182 +131,159 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
         <div className="absolute bottom-20 right-10 w-40 h-40 bg-secondary/10 rounded-full blur-xl z-0" />
 
         {/* Navigation Bar */}
-        {navbarOpacity === 0 && (
-          <nav className="fixed left-1/2 transform -translate-x-1/2 z-50 w-full max-w-none top-4 py-4 px-6">
-            <div className="flex justify-between items-center mx-20">
-              {/* Logo */}
+        <nav
+          className={`fixed left-1/2 top-3 z-50 w-full max-w-[90vw] sm:max-w-4xl lg:max-w-6xl -translate-x-1/2 px-4 sm:px-6 transition-all duration-300 ${
+            isScrolled ? "md:top-4" : "md:top-6"
+          }`}
+        >
+          <div
+            style={
+              isScrolled
+                ? {
+                    background: `rgba(0, 82, 255, ${0.8 * Math.max(navbarOpacity, 0.3)})`,
+                    backdropFilter: "blur(12px)",
+                    border: `1px solid rgba(0, 82, 255, ${0.3 * navbarOpacity})`,
+                    borderRadius: "1.5rem",
+                  }
+                : {
+                    background: "rgba(255, 255, 255, 0.65)",
+                    backdropFilter: "blur(12px)",
+                    borderRadius: "1.5rem",
+                  }
+            }
+            className="w-full border border-white/30 shadow-lg"
+          >
+            <div className="flex items-center justify-between gap-4 px-4 py-3 sm:px-6">
               <div className="flex items-center gap-3">
-                <img src="/Logo.png" alt="AnamAI Logo" className="w-20 h-20"/>
-                <motion.div
+                <img
+                  src="/Logo.png"
+                  alt="AnamAI Logo"
+                  className="h-12 w-12 sm:h-16 sm:w-16"
+                />
+                <motion.button
+                  type="button"
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
                   onClick={() => {
-                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                    setIsMobileMenuOpen(false);
                   }}
-                  className="text-black text-5xl drop-shadow-lg pr-6 cursor-pointer transition-all duration-300 hover:text-blue-200"
+                  className={`text-3xl font-bold leading-none transition-colors duration-300 sm:text-4xl ${
+                    isScrolled ? "text-white" : "text-black"
+                  }`}
                 >
-                  <span style={{ color: '#000000' }}>anam</span>
-  <span style={{ color: '#2B7FFF' }}>ai</span>
-                </motion.div>
+                  <span className="text-black">anam</span>
+                  <span className="text-primary">ai</span>
+                </motion.button>
               </div>
 
-              {/* Navigation Links */}
-              <div className="flex items-center gap-4 text-black/90 font-sans text-lg font-semibold drop-shadow-md">
-                {isMounted && <LanguageSwitcher />}
+              <div className="hidden items-center gap-4 font-sans text-sm font-semibold md:flex lg:text-base">
+                {isMounted && (
+                  <div className="w-[160px] lg:w-[180px]">
+                    <LanguageSwitcher />
+                  </div>
+                )}
+                {navItems.map((item) => (
+                  <motion.button
+                    key={item.key}
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    onClick={item.action}
+                    className={`rounded-lg px-3 py-2 transition-all duration-200 ${
+                      isScrolled
+                        ? "text-white/90 hover:bg-white/10 hover:text-white"
+                        : "text-black/80 hover:bg-black/5 hover:text-black"
+                    }`}
+                  >
+                    {item.label}
+                  </motion.button>
+                ))}
                 <motion.button
-                  whileHover={{ scale: 1.1 }}
+                  whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
                   onClick={() => {
-                    const element = document.getElementById('why-choose-anamai');
-                    if (element) {
-                      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
+                    onBeginJourney();
+                    setIsMobileMenuOpen(false);
                   }}
-                  className="hover:text-black transition-all duration-300 px-4 py-2 rounded-lg hover:bg-white/10"
-                >
-                  {t("hero_ourMission")}
-                </motion.button>
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
-                  onClick={() => {
-                    const element = document.getElementById('wellness-journey');
-                    if (element) {
-                      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
-                  }}
-                  className="hover:text-black transition-all duration-300 px-4 py-2 rounded-lg hover:bg-white/10"
-                >
-                  {t("hero_resources")}
-                </motion.button>
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
-                  onClick={() => {
-                    const element = document.getElementById('faq-section');
-                    if (element) {
-                      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
-                  }}
-                  className="hover:text-black transition-all duration-300 px-4 py-2 rounded-lg hover:bg-white/10"
-                >
-                  {t("hero_faq")}
-                </motion.button>
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
-                  onClick={onBeginJourney}
-                  className="btn-sweep group text-white font-sans font-semibold bg-blue-500 px-4 py-2 rounded-lg text-lg hover:shadow-2xl transition-all duration-300 shadow-xl drop-shadow-2xl"
+                  className="btn-sweep group rounded-lg bg-blue-500 px-4 py-2 text-sm font-semibold text-white shadow-xl transition-all duration-300 hover:shadow-2xl lg:px-5 lg:py-2.5 lg:text-base"
                 >
                   {t("hero_button")}
                 </motion.button>
               </div>
-            </div>
-          </nav>
-        )}
 
-        {navbarOpacity > 0 && (
-          <nav
-            className="fixed left-1/2 transform -translate-x-1/2 z-50 w-auto max-w-2xl top-2 py-2 px-4"
-            style={{
-              background: `rgba(0, 82, 255, ${0.8 * navbarOpacity})`,
-              backdropFilter: 'blur(8px)',
-              border: `1px solid rgba(0, 82, 255, ${0.3 * navbarOpacity})`,
-              borderRadius: '1rem',
-            }}
-          >
-            <div className="flex justify-between items-center">
-              {/* Logo */}
-              <div className="flex items-center gap-2">
-                <img src="/Logo.png" alt="AnamAI Logo" className="w-10 h-10"/>
+              <button
+                type="button"
+                className={`inline-flex items-center justify-center rounded-lg border border-transparent p-2 md:hidden ${
+                  isScrolled ? "text-white" : "text-black"
+                }`}
+                onClick={() => setIsMobileMenuOpen((prev) => !prev)}
+                aria-label="Toggle navigation menu"
+              >
+                {isMobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+              </button>
+            </div>
+
+            <AnimatePresence>
+              {isMobileMenuOpen && (
                 <motion.div
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  onClick={() => {
-                    window.scrollTo({ top: 0, behavior: 'smooth' });
-                  }}
-                  className="text-white text-xl drop-shadow-lg cursor-pointer transition-all duration-300 hover:text-blue-200 mr-8"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="flex flex-col gap-3 px-4 pb-4 md:hidden"
                 >
-                  AnamAI
+                  {isMounted && (
+                    <div className="w-full">
+                      <LanguageSwitcher />
+                    </div>
+                  )}
+                  {navItems.map((item) => (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={item.action}
+                      className="w-full rounded-lg bg-white/70 px-4 py-2 text-left text-sm font-semibold text-foreground shadow-sm transition hover:bg-white"
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onBeginJourney();
+                      setIsMobileMenuOpen(false);
+                    }}
+                    className="w-full rounded-lg bg-blue-500 px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-600"
+                  >
+                    {t("hero_button")}
+                  </button>
                 </motion.div>
-              </div>
-
-              {/* Navigation Links */}
-              <div className="flex items-center gap-2 text-white/90 font-sans text-sm font-semibold drop-shadow-md">
-                {isMounted && <LanguageSwitcher />}
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
-                  onClick={() => {
-                    const element = document.getElementById('why-choose-anamai');
-                    if (element) {
-                      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
-                  }}
-                  className="hover:text-white cursor-pointer transition-all duration-300 px-3 py-1 rounded-lg hover:bg-white/10"
-                >
-                  {t("hero_ourMission")}
-                </motion.button>
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
-                  onClick={() => {
-                    const element = document.getElementById('wellness-journey');
-                    if (element) {
-                      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
-                  }}
-                  className="hover:text-white cursor-pointer transition-all duration-300 px-3 py-1 rounded-lg hover:bg-white/10"
-                >
-                  {t("hero_resources")}
-                </motion.button>
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ type: "spring", stiffness: 300 }}
-                  onClick={() => {
-                    const element = document.getElementById('faq-section');
-                    if (element) {
-                      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
-                  }}
-                  className="hover:text-white cursor-pointer transition-all duration-300 px-3 py-1 rounded-lg hover:bg-white/10"
-                >
-                  {t("hero_faq")}
-                </motion.button>
-              </div>
-            </div>
-          </nav>
-        )}
+              )}
+            </AnimatePresence>
+          </div>
+        </nav>
 
         {/* Hero Content */}
-        <div className="relative z-10 flex pl-12 items-center justify-start h-screen">
-          <div className="px-6 lg:px-12">
-            <motion.div 
+        <div className="relative z-10 flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center px-4 py-24 text-center sm:px-6 md:items-start md:text-left lg:px-12">
+          <div className="w-full max-w-3xl">
+            <motion.div
               initial={{ opacity: 0, x: -50 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8, ease: "easeOut" }}
-              className="max-w-2xl fade-in text-left"
+              className="fade-in"
             >
               {/* Hero Heading */}
-              <motion.h1 
+              <motion.h1
                 initial={{ opacity: 0, y: 30 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.2 }}
-                className="font-serif text-black text-4xl lg:text-6xl font-bold tracking-tight mb-8 drop-shadow-2xl"
+                className="mb-6 font-serif text-3xl font-bold leading-tight tracking-tight text-black drop-shadow-2xl sm:text-4xl lg:text-6xl"
               >
                 {t("hero_title")}
               </motion.h1>
 
               {/* Call to Action Buttons */}
-              <div className="flex flex-col items-start gap-4">
-                <div className="flex items-center gap-4">
+              <div className="flex w-full flex-col items-stretch gap-4 sm:w-auto sm:items-start">
+                <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
                   <motion.button
                   initial={{ opacity: 0, y: 30 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -290,7 +292,7 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
                   whileTap={{ scale: 0.95 }}
                   onClick={handleMakeCall}
                   id="fancy"
-                  className="btn-sweep group text-white font-sans font-semibold bg-blue-500 px-[2.3rem] py-[1.15rem] rounded-lg text-[1.5rem] hover:shadow-2xl transition-all duration-300 shadow-xl drop-shadow-2xl"
+                  className="btn-sweep group rounded-lg bg-blue-500 px-6 py-3 text-base font-sans font-semibold text-white shadow-xl transition-all duration-300 hover:shadow-2xl sm:text-lg"
                   >
                   Call <span style={{ color: 'white' }}>anam</span>
           <span style={{ color: 'yellow' }}>ai</span>
@@ -301,27 +303,31 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
                     initial={{ opacity: 0, y: 30 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.8, delay: 0.6 }}
-                    className="flex items-center gap-2 bg-black/20 p-2 rounded-lg"
+                    className="flex flex-col gap-3 rounded-lg bg-black/20 p-3 text-left sm:flex-row sm:items-center"
                   >
                     <input
                       type="tel"
                       value={phoneNumber}
                       onChange={(e) => setPhoneNumber(e.target.value)}
                       placeholder="+1234567890"
-                      className="bg-white/90 text-black px-4 py-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-500"
+                      className="w-full rounded-lg bg-white/90 px-4 py-3 text-base text-black placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:flex-1"
                     />
                     <motion.button
                       whileHover={{ scale: 1.05 }}
                       whileTap={{ scale: 0.95 }}
                       onClick={handleMakeCall}
                       disabled={isCalling}
-                      className="bg-blue-500 text-white font-semibold px-6 py-3 rounded-lg hover:bg-blue-600 transition-all duration-300 disabled:bg-gray-400 disabled:cursor-not-allowed"
+                      className="rounded-lg bg-blue-500 px-6 py-3 font-semibold text-white transition-all duration-300 hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-gray-400"
                     >
                       {isCalling ? 'Calling...' : 'Call'}
                     </motion.button>
                   </motion.div>
                 )}
-                {callStatus && <p className="mt-2 text-sm text-white bg-black/50 px-3 py-1 rounded">{callStatus}</p>}
+                {callStatus && (
+                  <p className="mt-1 rounded bg-black/50 px-3 py-2 text-sm text-white">
+                    {callStatus}
+                  </p>
+                )}
               </div>
             </motion.div>
           </div>

--- a/components/sections/SessionSnapshots.tsx
+++ b/components/sections/SessionSnapshots.tsx
@@ -18,7 +18,7 @@ export const SessionSnapshots: React.FC<SessionSnapshotsProps> = ({
   if (!snapshots || snapshots.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        {t("sessions_noHistory")}
+        {t("sessions_completeForHistory")}
       </p>
     );
   }

--- a/contexts/LanguageContext.tsx
+++ b/contexts/LanguageContext.tsx
@@ -4,10 +4,13 @@ import { createContext, useState, useEffect, ReactNode, FC } from 'react';
 interface LanguageContextType {
   language: string;
   setLanguage: (language: string) => void;
-  translations: any;
+  translations: Record<string, string>;
+  fallbackTranslations: Record<string, string>;
 }
 
-export const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+export const LanguageContext = createContext<LanguageContextType | undefined>(
+  undefined
+);
 
 export const LanguageProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [language, setLanguage] = useState(() => {
@@ -16,23 +19,48 @@ export const LanguageProvider: FC<{ children: ReactNode }> = ({ children }) => {
     }
     return 'en';
   });
-  const [translations, setTranslations] = useState({});
+  const [translations, setTranslations] = useState<Record<string, string>>({});
+  const [fallbackTranslations, setFallbackTranslations] = useState<
+    Record<string, string>
+  >({});
+
+  useEffect(() => {
+    const loadFallbackTranslations = async () => {
+      try {
+        const enTranslations = await import(`../locales/en.json`);
+        setFallbackTranslations(enTranslations.default);
+        setTranslations(enTranslations.default);
+      } catch (error) {
+        console.error('Could not load default English translations', error);
+      }
+    };
+
+    loadFallbackTranslations();
+  }, []);
 
   useEffect(() => {
     const loadTranslations = async () => {
+      if (Object.keys(fallbackTranslations).length === 0) {
+        return;
+      }
+
+      if (language === 'en') {
+        setTranslations(fallbackTranslations);
+        return;
+      }
+
       try {
         const newTranslations = await import(`../locales/${language}.json`);
         setTranslations(newTranslations.default);
       } catch (error) {
         console.error(`Could not load translations for ${language}`, error);
         // Fallback to English if the selected language file is not found
-        const enTranslations = await import(`../locales/en.json`);
-        setTranslations(enTranslations.default);
+        setTranslations(fallbackTranslations);
       }
     };
 
     loadTranslations();
-  }, [language]);
+  }, [language, fallbackTranslations]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -44,6 +72,7 @@ export const LanguageProvider: FC<{ children: ReactNode }> = ({ children }) => {
     language,
     setLanguage,
     translations,
+    fallbackTranslations,
   };
 
   return (

--- a/hooks/useTranslation.ts
+++ b/hooks/useTranslation.ts
@@ -8,7 +8,11 @@ export const useTranslation = () => {
   }
 
   const t = (key: string, params: { [key: string]: string } = {}) => {
-    let translation = context.translations[key] || key;
+    const translationValue =
+      context.translations[key] ??
+      context.fallbackTranslations?.[key] ??
+      key;
+    let translation = translationValue;
     Object.keys(params).forEach(param => {
       translation = translation.replace(`{${param}}`, params[param]);
     });


### PR DESCRIPTION
## Summary
- redesign the landing hero navigation with a mobile menu, responsive call-to-action layout, and refined spacing so the page reads well on small screens
- adjust content, FAQ, and footer sections with mobile-aware paddings and corrected translation key usage to keep copy readable instead of showing raw keys
- add an English fallback in the language context/translation hook and reuse existing session copy so untranslated keys no longer leak into the UI

## Testing
- pnpm lint *(fails: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68e1fa3718988323980b998cde57e18b